### PR TITLE
cleanup composer.json

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,4 +54,5 @@ jobs:
           mysql -uroot -h127.0.0.1 -proot -e 'create database zf;'
           mysql -uroot -h127.0.0.1 -proot zf < tests/schema.sql
 
-      - run: vendor/bin/phpunit
+      - run: vendor/bin/phpunit --testsuite phpstan
+      - run: vendor/bin/phpunit --testsuite rector

--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,12 @@
     "require": {
         "php": "^8.0",
         "nikic/php-parser": "^4.13",
-        "phpstan/phpstan": "^1.2",
         "rector/rector": "^0.12",
         "zendframework/zendframework1": "^1.12"
     },
     "require-dev": {
         "ext-pdo": "*",
-        "friendsofphp/php-cs-fixer": "3.4.0",
-        "phpstan/phpstan-php-parser": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/phpstan-strict-rules": "^1.1",
-        "phpunit/phpunit": "^9",
-        "symplify/phpstan-extensions": "^10.0"
+        "phpunit/phpunit": "^9.5"
     },
 
     "autoload": {
@@ -25,7 +19,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "staabm\\ZfSelectStrip\\Tests\\": "tests/"
+            "staabm\\ZfSelectStrip\\Tests\\": "tests/",
+            "staabm\\ZfSelectStrip\\Tests\\Rector\\": "tests/rector",
+            "staabm\\ZfSelectStrip\\Tests\\PHPStan\\": "tests/phpstan"
         },
         "classmap": [
             "tests/classes/"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,8 @@
 
     <testsuites>
         <testsuite name="ZfSelectStrip">
-            <directory suffix="Test.php">tests/</directory>
+            <directory>tests/rector</directory>
+            <directory>tests/phpstan</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,9 +13,11 @@
          verbose="false">
 
     <testsuites>
-        <testsuite name="ZfSelectStrip">
-            <directory>tests/rector</directory>
+        <testsuite name="phpstan">
             <directory>tests/phpstan</directory>
+        </testsuite>
+        <testsuite name="rector">
+            <directory>tests/rector</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
The situation behaves as expected, beacuse PHPStan and Rector both preload their own version of php-parser. Each of them once.
They usually run standalone, so this won't colide. But in case of test in one preload for all they conflict.

- PHPStan preloads it's own php-parser :heavy_check_mark: 
- Rector tried to preload it's own php-parser, but some classes are already preloaded because of phpstan :red_circle: 

As they can't know about each other preloads, there is no clear solution to this. The best way that comes to my mind is to run tests in 2 separate parallel jobs (the CI will need more split then what I've sent). That way both preloads are safe in its own autoloader stream :+1: 

Btw, the dev packages have wrong namespace, I tried to fix that, see `composer.json` autolaod-dev and PSR-4.

I tried to run test locally too, but it depends on database and crashes. It should not depend on any external service, as the static feature of both PHPStan and Rector is now broken to dynamic.