### PR TITLE
separated test-suite for rector/phpstan required, to work arround cannot "redeclare interface/class errors"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,4 +15,3 @@ indent_size = 2
 
 [composer.json]
 indent_size = 4
-indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 indent_style = space
 
-[*.{neon, md, php,phpt}]
+[*.{neon, md, php, phpt}]
 indent_size = 4
 
 [*.{yaml,yml}]

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -52,4 +52,4 @@ jobs:
           mysql -uroot -h127.0.0.1 -proot -e 'create database zf;'
           mysql -uroot -h127.0.0.1 -proot zf < tests/schema.sql
 
-      - run: vendor/bin/phpstan
+      - run: composer phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,4 +54,7 @@ jobs:
           mysql -uroot -h127.0.0.1 -proot -e 'create database zf;'
           mysql -uroot -h127.0.0.1 -proot zf < tests/schema.sql
 
-      - run: vendor/bin/phpunit
+      # separated test-suite for rector/phpstan required, to prevent nikic/php-parser version conflicts
+      # which lead to cannot "redeclare interface/class errors" of PhpParser\* classes
+      # see https://github.com/rectorphp/rector/discussions/6958
+      - run: composer phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,54 @@
 {
-    "name": "staabm/zf-select-strip",
-    "license": "MIT",
-    "require": {
-        "php": "^8.0",
-        "nikic/php-parser": "^4.13",
-        "phpstan/phpstan": "^1.2",
-        "rector/rector": "^0.12",
-        "zendframework/zendframework1": "^1.12"
-    },
-    "require-dev": {
-        "ext-pdo": "*",
-        "friendsofphp/php-cs-fixer": "3.4.0",
-        "phpstan/phpstan-php-parser": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/phpstan-strict-rules": "^1.1",
-        "phpunit/phpunit": "^9",
-        "symplify/phpstan-extensions": "^10.0"
-    },
-
-    "autoload": {
-        "psr-4": {
-            "staabm\\ZfSelectStrip\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "staabm\\ZfSelectStrip\\Tests\\": "tests/"
-        },
-        "classmap": [
-            "tests/classes/"
-        ]
-    },
-    "scripts": {
-        "csfix": [
-            "php-cs-fixer fix"
-        ],
-        "phpstan-dba-baseline": [
-            "phpunit",
-            "phpstan analyse -c phpstan.neon.dist"
-        ],
-        "phpstan": [
-            "phpstan analyse -c phpstan.neon.dist"
-        ],
-        "phpunit": [
-            "phpunit"
-        ]
-    },
-    "config": {
-        "optimize-autoloader": true,
-        "sort-packages": true
-    }
+	"name": "staabm/zf-select-strip",
+	"license": "MIT",
+	"require": {
+		"php": "^8.0",
+		"nikic/php-parser": "^4.13",
+		"phpstan/phpstan": "^1.2",
+		"rector/rector": "^0.12",
+		"zendframework/zendframework1": "^1.12"
+	},
+	"require-dev": {
+		"ext-pdo": "*",
+		"friendsofphp/php-cs-fixer": "3.4.0",
+		"phpstan/phpstan-php-parser": "^1.1",
+		"phpstan/phpstan-phpunit": "^1.0",
+		"phpstan/phpstan-strict-rules": "^1.1",
+		"phpunit/phpunit": "^9",
+		"symplify/phpstan-extensions": "^10.0"
+	},
+	"autoload": {
+		"psr-4": {
+			"staabm\\ZfSelectStrip\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"staabm\\ZfSelectStrip\\Tests\\": "tests/"
+		},
+		"classmap": [
+			"tests/classes/"
+		]
+	},
+	"scripts": {
+		"csfix": [
+			"php-cs-fixer fix"
+		],
+		"test": [
+			"@phpstan",
+			"@phpunit",
+			"@csfix"
+		],
+		"phpstan": [
+			"phpstan analyse -c phpstan.neon.dist"
+		],
+		"phpunit": [
+			"phpunit --testsuite phpstan",
+			"phpunit --testsuite rector"
+		]
+	},
+	"config": {
+		"optimize-autoloader": true,
+		"sort-packages": true
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,54 +1,54 @@
 {
-	"name": "staabm/zf-select-strip",
-	"license": "MIT",
-	"require": {
-		"php": "^8.0",
-		"nikic/php-parser": "^4.13",
-		"phpstan/phpstan": "^1.2",
-		"rector/rector": "^0.12",
-		"zendframework/zendframework1": "^1.12"
-	},
-	"require-dev": {
-		"ext-pdo": "*",
-		"friendsofphp/php-cs-fixer": "3.4.0",
-		"phpstan/phpstan-php-parser": "^1.1",
-		"phpstan/phpstan-phpunit": "^1.0",
-		"phpstan/phpstan-strict-rules": "^1.1",
-		"phpunit/phpunit": "^9",
-		"symplify/phpstan-extensions": "^10.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"staabm\\ZfSelectStrip\\": "src/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"staabm\\ZfSelectStrip\\Tests\\": "tests/"
-		},
-		"classmap": [
-			"tests/classes/"
-		]
-	},
-	"scripts": {
-		"csfix": [
-			"php-cs-fixer fix"
-		],
-		"test": [
-			"@phpstan",
-			"@phpunit",
-			"@csfix"
-		],
-		"phpstan": [
-			"phpstan analyse -c phpstan.neon.dist"
-		],
-		"phpunit": [
-			"phpunit --testsuite phpstan",
-			"phpunit --testsuite rector"
-		]
-	},
-	"config": {
-		"optimize-autoloader": true,
-		"sort-packages": true
-	}
+    "name": "staabm/zf-select-strip",
+    "license": "MIT",
+    "require": {
+        "php": "^8.0",
+        "nikic/php-parser": "^4.13",
+        "phpstan/phpstan": "^1.2",
+        "rector/rector": "^0.12",
+        "zendframework/zendframework1": "^1.12"
+    },
+    "require-dev": {
+        "ext-pdo": "*",
+        "friendsofphp/php-cs-fixer": "3.4.0",
+        "phpstan/phpstan-php-parser": "^1.1",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-strict-rules": "^1.1",
+        "phpunit/phpunit": "^9",
+        "symplify/phpstan-extensions": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "staabm\\ZfSelectStrip\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "staabm\\ZfSelectStrip\\Tests\\": "tests/"
+        },
+        "classmap": [
+            "tests/classes/"
+        ]
+    },
+    "scripts": {
+        "csfix": [
+            "php-cs-fixer fix"
+        ],
+        "test": [
+            "@phpstan",
+            "@phpunit",
+            "@csfix"
+        ],
+        "phpstan": [
+            "phpstan analyse -c phpstan.neon.dist"
+        ],
+        "phpunit": [
+            "phpunit --testsuite phpstan",
+            "phpunit --testsuite rector"
+        ]
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,8 +13,11 @@
          verbose="false">
 
     <testsuites>
-        <testsuite name="ZfSelectStrip">
-            <directory suffix="Test.php">tests/</directory>
+        <testsuite name="phpstan">
+            <directory suffix="Test.php">tests/phpstan</directory>
+        </testsuite>
+        <testsuite name="rector">
+            <directory suffix="Test.php">tests/rector/</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
separated test-suite for rector/phpstan required, to prevent `nikic/php-parser` version conflicts which lead to `cannot redeclare interface/class errors` of PhpParser\* classes

see https://github.com/rectorphp/rector/discussions/6958

based on the investigation of Tomas Votruba in https://github.com/staabm/zf-select-strip/pull/8